### PR TITLE
Change repo url to "main" instead of "master"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -125,7 +125,7 @@
 			</div>
 			<div id="custom-url-wrapper" class="header-links"><input id="customUrlButton" value="Submit" onclick="vodURL(document.getElementById('customUrlText').value)" type="button"></div>
 			<div id="git-buttons" class="header-links">
-				<div><a class="github-button" href="https://github.com/vyneer/orvods-go/commits/master" data-icon="octicon-repo-forked" aria-label="Check the commits for orvods-go">Commits</a></div>
+				<div><a class="github-button" href="https://github.com/vyneer/orvods-go/commits/main" data-icon="octicon-repo-forked" aria-label="Check the commits for orvods-go">Commits</a></div>
 				<div><a class="github-button" href="https://github.com/vyneer/orvods-go/issues" data-icon="octicon-issue-opened" aria-label="Issue vyneer/orvods-go on GitHub">Issue</a></div>
 			</div>
 		</div>


### PR DESCRIPTION
vyneer is not a colonizer. They show that by renaming the m-word branch to main. Good on them. Sadly the website is not as woke as the repo. We need to fix this asap otherwise a certain canadian bully will doxx vyneer. PepeHands