### PR TITLE
Adding support for `/live/` YouTube URLs

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -136,6 +136,9 @@ function vodURL(url) {
         }
         if (urlCheck.hostname === "www.youtube.com" || urlCheck.hostname === "youtube.com") {
             if (!platforms.includes("youtube")) return;
+            if (urlCheck.pathname.includes("/live/")) {
+                window.location.href = window.location.origin + window.location.pathname + "?v=" + urlCheck.pathname.slice(6) + urlCheck.search.replace(/[?]/gm, '&') + timestamps;
+            }
             window.location.href = window.location.origin + window.location.pathname + urlCheck.search + timestamps;
         }
         if (urlCheck.hostname === "youtu.be") {

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -138,8 +138,9 @@ function vodURL(url) {
             if (!platforms.includes("youtube")) return;
             if (urlCheck.pathname.includes("/live/")) {
                 window.location.href = window.location.origin + window.location.pathname + "?v=" + urlCheck.pathname.slice(6) + urlCheck.search.replace(/[?]/gm, '&') + timestamps;
+            } else {
+                window.location.href = window.location.origin + window.location.pathname + urlCheck.search + timestamps;
             }
-            window.location.href = window.location.origin + window.location.pathname + urlCheck.search + timestamps;
         }
         if (urlCheck.hostname === "youtu.be") {
             if (!platforms.includes("youtube")) return;


### PR DESCRIPTION
When getting the link for a vod on youtube from any iteration of the official app (not desktop), YouTube will have a redirect link of the form `https://youtube.com/live/...` rather than `watch?v=`. The live redirect doesn't seem to be a supported URL.

I've just extended the youtube URLs in a similar way `youtu.be` is implemented. :) 